### PR TITLE
fix Compile error

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,7 @@
 #include <Arduino.h>
 #include "config.h"
 #include <Base64.h>
+#include <LoRa_APP.h>
 #include "cyPm.c"
 
 // CONFIGURATION: 


### PR DESCRIPTION
Cubecell SDK was updated. Code will probably not work with the current 1.2 firmware, but at least it compiles again.